### PR TITLE
バグの修正

### DIFF
--- a/ddt-regular/css/smartphone.css
+++ b/ddt-regular/css/smartphone.css
@@ -345,14 +345,14 @@
 	}
 	/* 小ロゴに対するスタイルシート */
 	#smalllogo{
-		font-size : 11px;	/* 通常より小さい文字にする */
+		font-size : 13px;	/* 通常より小さい文字にする */
 		padding-top : 0px;	/* 上paddingをなくす */
 		/* 2つあわせて回り込みを解除する */
 		float : none!important;
 		clear : both;
 	}
 #companylogo{
-	width: 135px;
+	width: 160px;
 }
 	
 	/* フッター内の会社ロゴについてのスタイルシート */

--- a/ddt-regular/css/smartphone.css
+++ b/ddt-regular/css/smartphone.css
@@ -345,22 +345,19 @@
 	}
 	/* 小ロゴに対するスタイルシート */
 	#smalllogo{
-		font-size : 13px;	/* 通常より小さい文字にする */
+		font-size : 11px;	/* 通常より小さい文字にする */
 		padding-top : 0px;	/* 上paddingをなくす */
 		/* 2つあわせて回り込みを解除する */
 		float : none!important;
 		clear : both;
 	}
 #companylogo{
-	width: 160px;
+	width: 135px;
 }
 	
 	/* フッター内の会社ロゴについてのスタイルシート */
 	span.footerlogo{
 		font-size: 24px;	/* フォントのサイズを24pxに指定 */
-		font-family: Impact, "メイリオ", "ＭＳ Ｐゴシック";	/* フォントをImpactに指定 */
-		font-weight: normal;	/* フォントを通常サイズにする */
-		color: #800000;			/* フォントの色をmaroon(ダークレッド系)にする */
 		width: auto;		/* 幅を自動調整する */
 	}
 	.baseaddress{
@@ -383,6 +380,8 @@
 	}
 	#ssn-d2124{
 		background-color: rgba(245, 245, 220, 0.7);
+		padding-right: 10.5px!important;
+		padding-left: 10.5px!important;
 	}
 	/* 開発サービスページの記事部分に関するスタイルシート */
 	/* 開発サービスの記事に関するスタイルシート */
@@ -729,7 +728,7 @@
  * 作成日 :2015.12.23
  */
 .Long-termTrineeLogo {
-	margin-bottom : 2px;	/* 下に2pxのmarginをセットして適切な間隔を取る */
+	margin-bottom : 5px;	/* 下に4pxのmarginをセットして適切な間隔を取る */
 }
 	
 	/* 

--- a/ddt-regular/css/style.css
+++ b/ddt-regular/css/style.css
@@ -519,13 +519,16 @@ header h3 {
 	color: #800000;			/* フォントの色をmaroon(ダークレッド系)にする */
 	width: auto;		/* 幅を自動調整する */
 }
+/* 会社ロゴ */
+.ddthinkLogo {
+ 	font-weight : bold;
+	color: #800000;
+	font-family: 'Teko', sans-serif; 
+	letter-spacing: -1.4px; /* 文字間調整 */
+}
 /* 大ロゴ */
 .biglogo-substitute {
-	font-family: 'Teko', sans-serif; 
 	font-size: 33px; 
-	/* 太字に指定する */
-	font-weight : bold;
-	color: #800000;
 	display: block; 
 	float:left; 
 	margin:-2px 2px 0 0;
@@ -534,10 +537,6 @@ header h3 {
 
 span.footerlogo{
 	font-size: 27px;	/* フォントのサイズを24pxに指定 */
-	font-family: 'Teko', sans-serif;	/* フォントをImpactに指定 */
-	/* 太字に指定する */
-	font-weight : bold;
-	color: #800000;			/* フォントの色をmaroon(ダークレッド系)にする */
 	width: auto;		/* 幅を自動調整する */
 	float: left;		/* 左に寄せる */
 }
@@ -1276,6 +1275,11 @@ span.text-red{
 	line-height: 34px;		/* １行当たりを適切な高さに調整する */
 }
 
+.Long-termTrineeLogo .logoText {
+	line-height: 22px;
+	padding: 10px 0 9px 13px;
+}
+
 /* 
  * セレクタ:.titleInTable
  * 概要   :研修制度「内容」右側部分
@@ -1284,6 +1288,7 @@ span.text-red{
  */
 .titleInTable {
 	font-weight: normal;
+	line-height: 11px;
 }
 
 /* 

--- a/ddt-regular/json/common.json
+++ b/ddt-regular/json/common.json
@@ -53,6 +53,7 @@
 					"id": "companylogo",
 					"biglogo-substitute": {
 						"id": "biglogo-substitute",
+						"class":"biglogo-substitute ddthinkLogo",
 						"text": "DDThink"
 					},
 					"smalllogo": {
@@ -118,6 +119,7 @@
 			"footerleft": {
 				"id": "footerleft",
 				"footerlogo": {
+					"class":"footerlogo ddthinkLogo",
 					"text": "DDThink"
 				},
 				"footercompanyname": {


### PR DESCRIPTION
修正内容、項目書の3,4,6
・ヘッダーの「DDThink」の文字とフッターの「DDThink」の文字フォントが異なるバグ
・ヘッダーの　「DDThinkdegital design think corporation」部分と「無料ゲームアプリダウンロード」が1列で表示されない
・「Long-term Training ethod」の部分が縦に大きくなりすぎてテーブルとの余白が「Trainee」や「Mid-career」などと同様になっていない。
